### PR TITLE
Use JWS and JWK for integrity check

### DIFF
--- a/draft-ietf-grow-nrtm-v4.txt
+++ b/draft-ietf-grow-nrtm-v4.txt
@@ -232,21 +232,13 @@ Internet-Draft                   NRTM v4                        May 2024
 
 3.  Mirror server use
 
-3.1.  Key Configuration <Check ont this>
+3.1.  Key Configuration
 
-   It is RECOMMENDED that JSON Web Signature (JWS) [RFC7515] and JSON
-   Web Key (JWK) [RFC7517] be used to sign and validate the JSON data
-   returned for a Bulk RDAP response.  It is further RECOMMENDED that
-   Elliptic Curve Digital Signature Algorithm (ECDSA) (Section 3.4 of
-   [RFC7518]) be used for JWS. The process for providing public key is 
-   not in scope of this protocol, but a typical case is publication on the 
-   operator's known website.  Key rotation is described in Section 8.4.
-
-   It is RECOMMENDED that implementations provide easily accessible
-   tools for operators to generate new Ed25519 keys to enter into their
-   configuration and assist with key rotation.  All configuration
-   options SHOULD be clearly named to indicate that they are private
-   keys.
+   It is RECOMMENDED that Elliptic Curve Digital Signature Algorithm (ECDSA) 
+   (Section 3.4 of [RFC7518]) be used for JWS to generate a key. 
+   The process for providing public key is not in scope of this protocol, 
+   but a typical case is publication on the operator's known website.  
+   Key rotation is described in Section 8.4.
 
 3.2.  Snapshot Initialization
 
@@ -609,10 +601,10 @@ Internet-Draft                   NRTM v4                        May 2024
    *  The type MUST be "notification".
 
    *  The optional field next_signing_key is used for in-band key
-      rotation.  <Check how to frame this>If present, it MUST be an Ed25519 [RFC8032] public key
-      encoded in base64 [RFC4648], which matches the private key the
-      mirror server will start using to sign the Update Notification
-      File in the near future.  Key rotation is described in
+      rotation. If present, it MUST be an JSON Web Key (JWK) [RFC8032] 
+      public key encoded in base64 [RFC4648] as mentioned in section 5, 
+      which matches the private key the mirror server will start using to 
+      sign the all Files in the near future. Key rotation is described in
       Section 8.4.  If there is no next signing key, this key MUST be
       omitted.
 
@@ -680,7 +672,6 @@ Internet-Draft                   NRTM v4                        May 2024
 6.3.  File format and validation
 
    Example Snapshot File:
-
    ␞{
      "nrtm_version": 4,
      "type": "snapshot",

--- a/draft-ietf-grow-nrtm-v4.txt
+++ b/draft-ietf-grow-nrtm-v4.txt
@@ -155,7 +155,7 @@ Internet-Draft                   NRTM v4                        May 2024
    mirroring by others.  This can be retrieved by mirror clients, which
    then load the IRR objects into their local storage.
 
-   Publication consists of three different files:
+   Publication consists of three different files :
 
 
 
@@ -180,10 +180,16 @@ Internet-Draft                   NRTM v4                        May 2024
    *  Zero or more Delta Files.  These contain the changes between two
       database version numbers.
 
-   The Update Notification file MUST be in the JavaScript Object
-   Notation (JSON) format [RFC8259].  The Snapshot File and Delta Files
-   MUST be in the JSON Text Sequences [RFC7464] format, so that each
-   object in large files can be parsed independently.  All files MUST
+
+   Note that each file will be signed using JSON Web Signature (JWS) [RFC7515] and
+   JSON Web Key (JWK) [RFC7517]. JWS response will have 3 parts seperated by dot:
+   Header , Payload and signature and each part is encoded in Base64URL.
+
+   Client must verify the signature using the public key, if it fails client must discard
+   the file. Payload part will have the file content. In case of Update Notification file ,
+   payload MUST be in the JavaScript Object Notation (JSON) format [RFC8259].  
+   If it is Snapshot File or  Delta Files, payload MUST be in the JSON Text Sequences [RFC7464] 
+   format, so that each object in large files can be parsed independently. All files MUST
    use UTF-8 encoding and MAY be compressed with GZIP [RFC1952].
 
    Mirror clients initially retrieve the small Update Notification File

--- a/draft-ietf-grow-nrtm-v4.txt
+++ b/draft-ietf-grow-nrtm-v4.txt
@@ -94,7 +94,6 @@ Table of Contents
      5.1.  Purpose . . . . . . . . . . . . . . . . . . . . . . . . .  10
      5.2.  Cache concerns  . . . . . . . . . . . . . . . . . . . . .  11
      5.3.  File format and validation  . . . . . . . . . . . . . . .  11
-     5.4.  Signature . . . . . . . . . . . . . . . . . . . . . . . .  13
    6.  Snapshot File . . . . . . . . . . . . . . . . . . . . . . . .  13
      6.1.  Purpose . . . . . . . . . . . . . . . . . . . . . . . . .  13
      6.2.  Cache Concerns  . . . . . . . . . . . . . . . . . . . . .  13
@@ -172,9 +171,7 @@ Internet-Draft                   NRTM v4                        May 2024
 
    *  A single Update Notification File.  This specifies the current
       Database version and locations of the Snapshot File and Delta
-      Files.  Additionally, there is an Update Notification Signature
-      File, used to verify the authenticity of the Update Notification
-      File.
+      Files. 
 
    *  A single active Snapshot File.  This contains all published IRR
       objects at a particular version.  The mirror server periodically
@@ -235,16 +232,15 @@ Internet-Draft                   NRTM v4                        May 2024
 
 3.  Mirror server use
 
-3.1.  Key Configuration
+3.1.  Key Configuration <Check ont this>
 
-   When enabling NRTMv4 publication for an IRR Database, the operator
-   MUST generate and configure a private Ed25519 [RFC8032] key.  The
-   operator then provides this public key, the name of the IRR Database,
-   and publication URL of the Update Notification File to any operators
-   of mirror clients.  The published public key MUST be encoded in
-   base64 [RFC4648].  The process for providing this is not in scope of
-   this protocol, but a typical case is publication on the operator's
-   known website.  Key rotation is described in Section 8.4.
+   It is RECOMMENDED that JSON Web Signature (JWS) [RFC7515] and JSON
+   Web Key (JWK) [RFC7517] be used to sign and validate the JSON data
+   returned for a Bulk RDAP response.  It is further RECOMMENDED that
+   Elliptic Curve Digital Signature Algorithm (ECDSA) (Section 3.4 of
+   [RFC7518]) be used for JWS. The process for providing public key is 
+   not in scope of this protocol, but a typical case is publication on the 
+   operator's known website.  Key rotation is described in Section 8.4.
 
    It is RECOMMENDED that implementations provide easily accessible
    tools for operators to generate new Ed25519 keys to enter into their
@@ -450,12 +446,6 @@ Romijn, et al.          Expires 17 November 2024                [Page 8]
 Internet-Draft                   NRTM v4                        May 2024
 
 
-   *  The mirror client MUST verify that the hash of the Snapshot File
-      matches the hash in the Update Notification File that referenced
-      it.  If the Snapshot File was compressed with GZIP, the hash MUST
-      match the compressed data.  In case of a mismatch of this hash,
-      the file MUST be rejected.
-
    *  The client MUST record the session_id and version of the loaded
       Snapshot File.
 
@@ -485,12 +475,6 @@ Internet-Draft                   NRTM v4                        May 2024
    *  The client MUST retrieve all Delta Files for versions since the
       client's last known version, if there are any.
 
-   *  The mirror client MUST verify that the hash of each newly
-      downloaded Delta File matches the hash in the Update Notification
-      File that referenced it.  If the Delta File was compressed with
-      GZIP, the hash MUST match the compressed file.  In case of a
-      mismatch of this hash, the Delta File MUST be rejected.
-
    *  The client MUST process all changes in the Delta Files in order:
       lowest Delta File version number first, and in the order of the
       changes list in the Delta File.
@@ -515,11 +499,10 @@ Internet-Draft                   NRTM v4                        May 2024
 4.4.  Signature and Staleness Verification
 
    Every time a mirror client retrieves a new version of the Update
-   Notification File, it MUST retrieve and verify the Update
-   Notification Signature File.  The signature MUST be valid for the
-   configured public key for the contents of the Update Notification
-   File.  If the signature does not match, the mirror client MUST reject
-   the Update Notification File, unless a key rotation is in progress as
+   Notification File, Snapshot file or Delta file , it MUST retrieve 
+   and verify the signature as per JWS specification.  
+   If the signature does not match, the mirror client MUST reject
+   the File, unless a key rotation is in progress as
    described in Section 8.4.
 
    A mirror client can use the generation timestamp in the Update
@@ -587,24 +570,20 @@ Internet-Draft                   NRTM v4                        May 2024
   "version": 4,
   "snapshot": {
     "version": 3,
-    "url": "https://example.com/ca128382-78d9-41d1-8927-1ecef15275be/nrtm-snapshot.2.047595d0fae972fbed0c51b4a41c7a349e0c47bb.json.gz",
-    "hash": "9a..86"
+    "url": "https://example.com/ca128382-78d9-41d1-8927-1ecef15275be/nrtm-snapshot.2.047595d0fae972fbed0c51b4a41c7a349e0c47bb.json.gz"
   },
   "deltas": [
     {
       "version": 2,
-      "url": "https://example.com/ca128382-78d9-41d1-8927-1ecef15275be/nrtm-delta.1.784a2a65aba22e001fd25a1b9e8544e058fbc703.json",
-      "hash": "62..a2"
+      "url": "https://example.com/ca128382-78d9-41d1-8927-1ecef15275be/nrtm-delta.1.784a2a65aba22e001fd25a1b9e8544e058fbc703.json"
     },
     {
       "version": 3,
-      "url": "https://example.com/ca128382-78d9-41d1-8927-1ecef15275be/nrtm-delta.2.0f681f07cfab5611f3681bf030ec9f6fa3442fb0.json",
-      "hash": "25..9a"
+      "url": "https://example.com/ca128382-78d9-41d1-8927-1ecef15275be/nrtm-delta.2.0f681f07cfab5611f3681bf030ec9f6fa3442fb0.json"
     },
     {
       "version": 4,
-      "url": "https://example.com/ca128382-78d9-41d1-8927-1ecef15275be/nrtm-delta.3.d9c194acbb2cb0d4088c9d8a25d5871cdd802c79.json",
-      "hash": "b4..13"
+      "url": "https://example.com/ca128382-78d9-41d1-8927-1ecef15275be/nrtm-delta.3.d9c194acbb2cb0d4088c9d8a25d5871cdd802c79.json"
     }
   ]
 }
@@ -618,9 +597,6 @@ Romijn, et al.          Expires 17 November 2024               [Page 11]
 Internet-Draft                   NRTM v4                        May 2024
 
 
-   Note: hash and key values in this example are shortened because of
-   formatting.
-
    The following validation rules MUST be observed when creating or
    parsing Update Notification Files:
 
@@ -633,7 +609,7 @@ Internet-Draft                   NRTM v4                        May 2024
    *  The type MUST be "notification".
 
    *  The optional field next_signing_key is used for in-band key
-      rotation.  If present, it MUST be an Ed25519 [RFC8032] public key
+      rotation.  <Check how to frame this>If present, it MUST be an Ed25519 [RFC8032] public key
       encoded in base64 [RFC4648], which matches the private key the
       mirror server will start using to sign the Update Notification
       File in the near future.  Key rotation is described in
@@ -655,15 +631,9 @@ Internet-Draft                   NRTM v4                        May 2024
    *  The deltas MUST have a sequential contiguous set of version
       numbers.
 
-   *  Each snapshot and delta element MUST have a version, HTTPS URL and
-      hash attribute.  If the snapshot or delta file was compressed with
-      GZIP, the filename MUST end in ".gz". and the hash MUST match the
-      compressed data.
-
-   *  The hash attribute in snapshot and delta elements MUST be the
-      hexadecimal encoding of the SHA-256 hash [SHS] of the referenced
-      file.  The mirror client MUST verify this hash when the file is
-      retrieved and reject the file if the hash does not match.
+   *  Each snapshot and delta element MUST have a version, HTTPS URL. 
+      If the snapshot or delta file was compressed with GZIP, the filename 
+      MUST end in ".gz". and the hash MUST match the compressed data.
 
 
 
@@ -673,29 +643,6 @@ Romijn, et al.          Expires 17 November 2024               [Page 12]
 
 Internet-Draft                   NRTM v4                        May 2024
 
-
-5.4.  Signature
-
-   The mirror server publishes a signature for each Update Notification
-   File, which the client uses to verify the contents against the known
-   public key.
-
-   *  The contents of Update Notification File MUST be signed using
-      Ed25519 [RFC8032].
-
-   *  The Update Notification File Signature File contains the Ed25519
-      signature encoded in base64 [RFC4648].
-
-   *  The Update Notification File Signature File MUST be published
-      under the same path as the Update Notification File, under the
-      filename "update-notification-file-[hash].sig", where the hash is
-      the hexadecimal encoding of the SHA-256 hash [SHS] of the Update
-      Notification File contents.
-
-   *  To avoid race conditions, the mirror server MUST publish the new
-      signature file before publishing the new Update Notification File,
-      and SHOULD retain old signature files for at least 5 minutes after
-      a new Update Notification File is published.
 
 6.  Snapshot File
 
@@ -729,11 +676,6 @@ Romijn, et al.          Expires 17 November 2024               [Page 13]
 
 Internet-Draft                   NRTM v4                        May 2024
 
-
-   To avoid race conditions where a mirror client retrieves an Update
-   Notification File moments before it's updated, mirror servers SHOULD
-   retain old Snapshot Files for at least 5 minutes after a new Update
-   Notification File is published.
 
 6.3.  File format and validation
 
@@ -1041,10 +983,12 @@ Internet-Draft                   NRTM v4                        May 2024
    authenticity, and there are various scenarios where mirroring may not
    be reliable.
 
-   NRTMv4 requires integrity verification.  The Delta and Snapshot Files
-   are verified using the SHA-256 hash in the Update Notification File,
-   and the Update Notification File is verified using its signature
-   file.  Additionally, the channel security offered by HTTPS further
+   NRTMv4 requires integrity verification. It is RECOMMENDED that 
+   JSON Web Signature (JWS) [RFC7515] and JSON Web Key (JWK) [RFC7517] 
+   be used to sign and validate the JSON datareturned for a Bulk RDAP response.  
+   It is further RECOMMENDED that Elliptic Curve Digital Signature Algorithm (ECDSA)
+   (Section 3.4 of [RFC7518]) be used for JWS.
+.  Additionally, the channel security offered by HTTPS further
    limits security risks.
 
    By allowing publication on any HTTPS endpoint, NRTMv4 allows for


### PR DESCRIPTION
This pull request provides an alternative way to verify integrity using JSON Web Signature (JWS) [RFC7515] and JSON Web Key (JWK) [RFC7517]  instead of using a separate signature  file for update notification file. 

This method allows us to avoid race condition with update notification file and update signature file as JWS sends the signature and payload together. 

This pull request also suggest to use JWS for verifying snapshot file and delta files instead of using hash in update notification file. So we no longer need to send the hash in update notification file.

Brief explanation of how JWS with JWT will work:

1. The response consists of three parts : Header, Payload and Signature
3. Each part will be encoded in Base64URL separated by dot. 
4. Header will contain basic information like algorithm used to generate the Keys. 
For example: {"alg":"ES256"}

5. Payload will have one of the NRTM file depending on the request
        * In case of Update Notification file , it will be in the JavaScript Object Notation (JSON) format [RFC8259].  
        *  If it is Snapshot File , payload will be in the JSON Text Sequences [RFC7464]  format and GIZIPPED
        *  For Delta Files,  payload will be in the JSON Text Sequences [RFC7464]  format 
        
6.  Third part will be signature client must verify signature using public key.