### PR TITLE
Address Roman Danyliw's comments

### DIFF
--- a/draft-ietf-grow-nrtm-v4.xml
+++ b/draft-ietf-grow-nrtm-v4.xml
@@ -654,7 +654,7 @@
         </li>
         <li>
           Implementations MUST support ES256 for interoperability.
-          The algorithm MUST NOT be Deprecated, and it is RECOMMENDED to use Recommended or Recommended+ algorithms, as listed in the IANA JOSE Algorithms registry <xref target="IANA_jose"/>.
+          The algorithm MUST NOT be Deprecated or Prohibited, and it is RECOMMENDED to use Recommended or Recommended+ algorithms, as listed in the IANA JOSE Algorithms registry <xref target="IANA_jose"/>.
         </li>
       </ul>
     </section>
@@ -992,7 +992,7 @@
       The authors would also like to thank
         Daniele Ceccarelli, Claudio Allocchio, Menachem Dodge, Julian Reschke, Watson Ladd and Paul Kyzivat,
       for their reviews during IETF Last Call.
-      The authors thank Gorry Fairhurst, Andy Newton, Éric Vyncke and Deb Cooley for the comments and feedback.
+      The authors thank Gorry Fairhurst, Andy Newton, Éric Vyncke, Deb Cooley and Roman Danyliw for the comments and feedback.
     </t>
   </section>
 


### PR DESCRIPTION
https://mailarchive.ietf.org/arch/msg/grow/bysqOa4aCiGUQWM5cIDUDKDecIk/

Note that Prohibited algorithms are also not supported for JOSE.

Re SHA-256:
The SHA-256 hash is intentionally fixed. The hash is security-relevant, as substitution of a different file that matches the hash in the signed Update Notification File would be problematic. However, to the best of my knowledge, SHA-256's resistance to this is not under any credible threat. Adding hash algorithm flexibility would introduce significant extra complexity (additional fields, negotiation, migration) that we don't feel is justified at this time.
